### PR TITLE
feat & fix: support script action 'entry' to fix KeyError; add sound play to fix 'Couldn't find music file:' errors

### DIFF
--- a/05_read_story.py
+++ b/05_read_story.py
@@ -45,6 +45,8 @@ scriptName = '6070108' # original Ancient Killer story
 #scriptName = '2761001' # Konosuba Pre-battle
 #scriptName = '2761002' # Konosuba Post-battle
 
+scriptName = '1100501' # to test script action: entry
+
 try:
     theScript = ParsedScriptFile(scriptName)
     theEnv = ScriptReaderEnv(theScript)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Do note that in total the downloaded and extracted data will take roughly 72 GB 
   - You can skip this step and still proceed to step 5.
 - 05_read_story.py - A story emulator for the PotK story files.
   - Currently only loads files by ID, set by a variable in the script itself.
-  - This will load without the converted sound files, it will simply be silent.
 
 ## License
 MIT

--- a/lib/PotkPaths.py
+++ b/lib/PotkPaths.py
@@ -11,7 +11,7 @@ class PotkPaths:
     masterdataPath = os.path.join(PATH, r'masterdata')
     scriptPath = os.path.join(masterdataPath, 'ScriptScript')
     streamingAssetPath = os.path.join(resRootPath, r'StreamingAssets')
-    soundRootPath = os.path.join(resRootPath, r'android\wav')
+    soundRootPath = os.path.join(streamingAssetPath, r'android\wav')
     bkgPath = r'Prefabs\BackGround'
     assetBundlePath = r'AssetBundle\Resources'
     maskPath = r'GUI\009-3_sozai'

--- a/lib/story_viewer/ParsedScriptFile.py
+++ b/lib/story_viewer/ParsedScriptFile.py
@@ -57,7 +57,10 @@ class ParsedScriptFile:
                     
                 case 'body':
                     # Add a new character to the scene (id)
-                    self.actions.extend([ScriptFileActions.AddCharacter(int(lispAction[1]))])
+                    self.actions.extend([ScriptFileActions.AddCharacter(int(lispAction[1]))])      
+                case 'entry':
+                    # Add a duplicated character to the scene (clone id, id)
+                    self.actions.extend([ScriptFileActions.AddCharacterCopy(int(lispAction[1]), int(lispAction[2]))])
                 case 'mask':
                     # Set the transparency mask on or off (id, on/off)
                     self.actions.extend([ScriptFileActions.SetCharacterMask(int(lispAction[1]), lispAction[2])])

--- a/lib/story_viewer/ScriptFileActions.py
+++ b/lib/story_viewer/ScriptFileActions.py
@@ -79,6 +79,12 @@ class ScriptFileActions:
             self.cid = cid
         def run(self, env):
             env.addCharacter(self.cid)
+    class AddCharacterCopy:
+        def __init__(self, eid, cid):
+            self.eid = eid
+            self.cid = cid
+        def run(self, env):
+            env.addCharacterCopy(self.eid, self.cid)
     class SetCharacterMask:
         def __init__(self, cid, mask):
             self.cid = cid

--- a/lib/story_viewer/ScriptReaderEnv.py
+++ b/lib/story_viewer/ScriptReaderEnv.py
@@ -150,6 +150,10 @@ class ScriptReaderEnv:
         self.characters[cid] = Character(cid)
         self.characterLayers[0] += [self.characters[cid]]
         self.updated = True
+    def addCharacterCopy(self,eid,cid):
+        self.characters[eid] = Character(cid)
+        self.characterLayers[0] += [self.characters[eid]]
+        self.updated = True
     def setCharacterLayer(self,cid,layer):
         c = self.characters[cid]
         self.characterLayers[c.layer].remove(c)


### PR DESCRIPTION
doc: 'entry' action is to load duplicated characters in scenario

**Before**: `05_read_story.py` quits with `KeyError`; sounds are missing

```
Unknown lisp action found: layer
Unknown lisp action found: layer
Unknown lisp action found: entry
Unknown lisp action found: entry
Unknown lisp action found: imagelayer
Unknown lisp action found: imagelayer
Unknown lisp action found: serif
Unknown lisp action found: serif
Unknown lisp action found: serif
Unknown lisp action found: imagelayer
Unknown lisp action found: imagelayer
Unknown lisp action found: layer
Unknown lisp action found: entry
Unknown lisp action found: entry
Unknown lisp action found: imagelayer
Unknown lisp action found: imagelayer
Unknown lisp action found: effectbody
Unknown lisp action found: effectpattern
Unknown lisp action found: effectstart
Unknown lisp action found: shake
Unknown lisp action found: serif
Unknown lisp action found: shake
Unknown lisp action found: layer
Unknown lisp action found: entry
Unknown lisp action found: entry
Unknown lisp action found: shake
Unknown lisp action found: serif
Unknown lisp action found: serif
Unknown lisp action found: serif
Unknown lisp action found: serif
Unknown lisp action found: shake
Unknown lisp action found: shake
Unknown lisp action found: shake
Unknown lisp action found: imagelayer
Unknown lisp action found: imagelayer
Unknown lisp action found: imagelayer
Unknown lisp action found: imagelayer
Unknown lisp action found: imagelayer
Unknown lisp action found: imagelayer
Unknown lisp action found: shake
Loaded script with 922 actions
Couldn't find music file: C:\Users\laqieer\source\repos\laqieer\PotK-Threnody\extracted\android\wav\BgmCueSheet/bgm005
Couldn't find music file: C:\Users\laqieer\source\repos\laqieer\PotK-Threnody\extracted\android\wav\VO_9970/oberon_0009
Traceback (most recent call last):
  File "C:\Users\laqieer\source\repos\laqieer\PotK-Threnody\05_read_story.py", line 67, in <module>
    theEnv = theEnv.update(gameDisplay)
  File "C:\Users\laqieer\source\repos\laqieer\PotK-Threnody\lib\story_viewer\ScriptReaderEnv.py", line 359, in update
    self.script.runNextAction(self)
  File "C:\Users\laqieer\source\repos\laqieer\PotK-Threnody\lib\story_viewer\ParsedScriptFile.py", line 157, in runNextAction
    self.actions[self.itr].run(env)
  File "C:\Users\laqieer\source\repos\laqieer\PotK-Threnody\lib\story_viewer\ScriptFileActions.py", line 105, in run
    env.setCharacterStoryPos(self.cid, self.pos)
  File "C:\Users\laqieer\source\repos\laqieer\PotK-Threnody\lib\story_viewer\ScriptReaderEnv.py", line 172, in setCharacterStoryPos
    self.characters[cid].setStoryPos(pos)
KeyError: 38200011
```

**After**: `05_read_story.py` shows the scene correctly; sounds play

![屏幕截图 2024-08-27 231553](https://github.com/user-attachments/assets/a4e5f32e-2579-444b-bb99-dfbae55b2ac3)
